### PR TITLE
Add python-openssl package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/debian:wheezy
 ENV DEBIAN_FRONTEND noninteractive
 # RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl && apt-get clean
-RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python && apt-get clean
+RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python python-openssl && apt-get clean
 # RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
 RUN wget --no-check-certificate https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1


### PR DESCRIPTION
python-openssl is necessary for gcloud auth. 
